### PR TITLE
Deprecated tox -downloadcache option removed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,6 @@ commands = flake8
 [testenv:venv]
 commands = {posargs}
 
-[tox:jenkins]
-downloadcache = ~/cache/pip
-
 [flake8]
 max-line-length = 120
 # TODO: ignored checks should be enabled in the future


### PR DESCRIPTION
Caching is enabled by default from pip version 6.0

More info:
https://testrun.org/tox/latest/config.html#confval-downloadcache=path
https://pip.pypa.io/en/stable/reference/pip_install/#caching

Change-Id: I54711ed40598e8ee4b0385199b14f743aa4e4f04
